### PR TITLE
add ia version parsing

### DIFF
--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -310,6 +310,7 @@ func (t *TfHelmValues) toHelmValues() (*HelmValues, diag.Diagnostics) {
 			RequestMemory:            t.CbIa.RequestMemory.ValueString(),
 			LimitCPU:                 t.CbIa.LimitCPU.ValueFloat32(),
 			LimitMemory:              t.CbIa.LimitMemory.ValueString(),
+			Version:                  t.CbIa.Version.ValueString(),
 		},
 		CbPostgres: Postgres{
 			Enabled:           t.CbPostgres.Enabled.ValueBool(),


### PR DESCRIPTION
We weren't parsing the IA Version, so we would give an empty one to the helm chart. This leaves a trailing `:` at the end of the container line, making the file invalid yaml.

https://github.com/ClearBlade/terraform-google-clearblade-iot-enterprise/pull/8